### PR TITLE
Allow newer requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 http://people.csail.mit.edu/hubert/pyaudio/packages/pyaudio-0.2.8.tar.gz
 scikits.samplerate
-requests==1.2.0
+requests>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
            "numpy",
            "pyaudio",
            "scikits.samplerate",
-           "requests==1.2.0",
+           "requests>=1.2.0",
       ],
 
       classifiers = [


### PR DESCRIPTION
Otherwise issues with other python modules that need a newer version of `requests`.

